### PR TITLE
allow the listener to remove itself returning false

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ register `listener` with the observable. `immediate` is true by default.
 
 A function `remove` is returned, calling this function deregisters the listener.
 
+Another way of deregistering the listener is by returning `false` from inside the
+listener function.
+
 ## observable.set(value=any)
 
 set the current value of this observable. Any registered listeners will be called.

--- a/test/trigger.js
+++ b/test/trigger.js
@@ -76,6 +76,63 @@ module.exports = function (observable) {
     t.end()
   })
 
+  tape('remove itself, simple', function (t) {
+    var o = observable()
+    t.plan(1)
+
+    o(function (val) {
+      t.equals(val, 10)
+      return false
+    })
+
+    o.set(10)
+
+    o.set(20)
+
+    t.end()
+  })
+
+
+  tape('remove itself, complex', function (t) {
+    var o = observable()
+    t.plan(5)
+
+    var remove = o(function (val) {
+      t.equals(val, 10)
+      return false
+    })
+
+    const expected = [10, 20]
+    // 2nd listener remains functional after 1st listener is removed
+    o(function (val) {
+      t.true(expected.length > 0)
+      t.equals(val, expected.shift())
+    })
+
+    o.set(10)
+
+    remove() // should do nothing
+
+    o.set(20)
+
+    t.end()
+  })
+
+  tape('remove itself (immediately)', function (t) {
+    var o = observable()
+
+    o.set(10)
+
+    o(function (val) {
+      t.equals(val, 10)
+      return false
+    }, true)
+
+    o.set(20)
+
+    t.end()
+  })
+
   tape('flatten recursion', function (t) {
     var o = observable()
 


### PR DESCRIPTION
This is similar to pull-stream `drain()` which allows `return false` to abort/remove the listener.

Will help in ssb-db2 in situations like this: https://github.com/ssb-ngi-pointer/ssb-db2/blob/564d66593df87d715f8e68735d778a708ed2e55c/db.js#L605 If we have a listener that runs synchronously, then the `remove()` function may not even be available for calling yet, which makes it impossible to synchronously remove the listener on the first event triggered.